### PR TITLE
Add LocalDelete of (remote) object

### DIFF
--- a/src/main/java/nl/tno/oorti/OORTIambassador.java
+++ b/src/main/java/nl/tno/oorti/OORTIambassador.java
@@ -380,6 +380,16 @@ public interface OORTIambassador extends RTIambassador {
           NotConnected,
           RTIinternalError;
 
+  void localDeleteObjectInstance(Object theObject)
+      throws OwnershipAcquisitionPending,
+          FederateOwnsAttributes,
+          ObjectInstanceNotKnown,
+          SaveInProgress,
+          RestoreInProgress,
+          FederateNotExecutionMember,
+          NotConnected,
+          RTIinternalError;
+
   void requestAttributeValueUpdate(Class clazz, byte[] userSuppliedTag)
       throws AttributeNotDefined,
           ObjectClassNotDefined,

--- a/src/main/java/nl/tno/oorti/impl/OORTIambassadorImpl.java
+++ b/src/main/java/nl/tno/oorti/impl/OORTIambassadorImpl.java
@@ -618,18 +618,6 @@ public class OORTIambassadorImpl extends NullRTIambassador implements OORTIambas
     ObjectClass oc = ec.getOcm().getObjectClassIfExists(clazz);
     rtiamb.unsubscribeObjectClass(oc.getClassHandle());
     oc.removeSubscriptions();
-
-    // also delete all remote object instances of this class
-    for (ObjectInstance oi : ec.getOim().getObjectInstances()) {
-      if (oi.getObjectClass().equals(oc)) {
-        try {
-          rtiamb.localDeleteObjectInstance(oi.getInstanceHandle());
-          ec.getOim().removeObjectInstance(oi);
-        } catch (OwnershipAcquisitionPending | FederateOwnsAttributes | ObjectInstanceNotKnown ex) {
-          // ignore these exceptions and continue with the next object instance
-        }
-      }
-    }
   }
 
   /////////////////////////
@@ -947,6 +935,24 @@ public class OORTIambassadorImpl extends NullRTIambassador implements OORTIambas
         rtiamb.deleteObjectInstance(oi.getInstanceHandle(), userSuppliedTag, theTime);
     ec.getOim().removeObjectInstance(oi);
     return retraction;
+  }
+
+  @Override
+  public void localDeleteObjectInstance(Object theObject)
+      throws OwnershipAcquisitionPending,
+          FederateOwnsAttributes,
+          ObjectInstanceNotKnown,
+          SaveInProgress,
+          RestoreInProgress,
+          FederateNotExecutionMember,
+          NotConnected,
+          RTIinternalError {
+
+    ExecutionContext ec = ecm.getExecutionContextIfExists();
+
+    ObjectInstance oi = ec.getOim().getObjectInstanceIfExists(theObject);
+    rtiamb.localDeleteObjectInstance(oi.getInstanceHandle());
+    ec.getOim().removeObjectInstance(oi);
   }
 
   @Override

--- a/src/main/java/nl/tno/oorti/impl/ObjectInstanceManager.java
+++ b/src/main/java/nl/tno/oorti/impl/ObjectInstanceManager.java
@@ -2,7 +2,6 @@ package nl.tno.oorti.impl;
 
 import hla.rti1516e.ObjectInstanceHandle;
 import hla.rti1516e.exceptions.ObjectInstanceNotKnown;
-import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import nl.tno.oorti.OOproperties;
@@ -72,10 +71,6 @@ public class ObjectInstanceManager {
     } else {
       return oi;
     }
-  }
-
-  public Collection<ObjectInstance> getObjectInstances() {
-    return this.object2instance.values();
   }
 
   public ObjectInstance removeObjectInstance(ObjectInstance objectInstance) {


### PR DESCRIPTION
While at this, also remove the deletion of all remote object instances when unsubscribing from a class. Leave this action to the federate, that can now use localDelete.